### PR TITLE
feat: Expose the NewRenderer function

### DIFF
--- a/markdown.go
+++ b/markdown.go
@@ -5,7 +5,10 @@ import (
 	"github.com/gomarkdown/markdown/parser"
 )
 
-func Render(source string, lineWidth int, leftPad int, opts ...Options) []byte {
+/// Extensions returns the bitmask of extensions supported by this renderer.
+/// The output of this function can be used to instantiate a new markdown
+/// parser using the `NewWithExtensions` function.
+func Extensions() parser.Extensions {
 	extensions := parser.NoIntraEmphasis        // Ignore emphasis markers inside words
 	extensions |= parser.Tables                 // Parse tables
 	extensions |= parser.FencedCode             // Parse fenced code blocks
@@ -18,9 +21,13 @@ func Render(source string, lineWidth int, leftPad int, opts ...Options) []byte {
 	extensions |= parser.LaxHTMLBlocks          // more in HTMLBlock, less in HTMLSpan
 	extensions |= parser.NoEmptyLineBeforeBlock // no need for new line before a list
 
-	p := parser.NewWithExtensions(extensions)
+	return extensions
+}
+
+func Render(source string, lineWidth int, leftPad int, opts ...Options) []byte {
+	p := parser.NewWithExtensions(Extensions())
 	nodes := md.Parse([]byte(source), p)
-	renderer := newRenderer(lineWidth, leftPad, opts...)
+	renderer := NewRenderer(lineWidth, leftPad, opts...)
 
 	return md.Render(nodes, renderer)
 }

--- a/renderer.go
+++ b/renderer.go
@@ -127,7 +127,8 @@ type renderer struct {
 	table *tableRenderer
 }
 
-func newRenderer(lineWidth int, leftPad int, opts ...Options) *renderer {
+/// NewRenderer creates a new instance of the console renderer
+func NewRenderer(lineWidth int, leftPad int, opts ...Options) *renderer {
 	r := &renderer{
 		lineWidth:       lineWidth,
 		leftPad:         leftPad,


### PR DESCRIPTION
this allows developers to work directly with the Renderer on ast.Node objects. Also added a new public Extensions func for developers to create the markdown parser