### PR TITLE
Fix #47 declare explicit string type in example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ func main() {
 
 	result := markdown.Render(string(source), 80, 6)
 
-	fmt.Println(result)
+	fmt.Println(string(result))
 }
 ```
 


### PR DESCRIPTION
Fixes https://github.com/MichaelMure/go-term-markdown/issues/47