### PR TITLE
feat: export ShadeFmt

### DIFF
--- a/options.go
+++ b/options.go
@@ -23,14 +23,14 @@ func WithImageDithering(mode DitheringMode) Options {
 }
 
 // Use a custom collection of ANSI colors for the headings
-func WithHeadingShades(shades []shadeFmt) Options {
+func WithHeadingShades(shades []ShadeFmt) Options {
 	return func(r *renderer) {
 		r.headingShade = shade(shades)
 	}
 }
 
 // Use a custom collection of ANSI colors for the blockquotes
-func WithBlockquoteShades(shades []shadeFmt) Options {
+func WithBlockquoteShades(shades []ShadeFmt) Options {
 	return func(r *renderer) {
 		r.blockQuoteShade = shade(shades)
 	}

--- a/shades.go
+++ b/shades.go
@@ -1,27 +1,27 @@
 package markdown
 
-var defaultHeadingShades = []shadeFmt{
+var defaultHeadingShades = []ShadeFmt{
 	GreenBold,
 	GreenBold,
 	HiGreen,
 	Green,
 }
 
-var defaultQuoteShades = []shadeFmt{
+var defaultQuoteShades = []ShadeFmt{
 	GreenBold,
 	GreenBold,
 	HiGreen,
 	Green,
 }
 
-type shadeFmt func(a ...interface{}) string
+type ShadeFmt func(a ...interface{}) string
 
-type levelShadeFmt func(level int) shadeFmt
+type levelShadeFmt func(level int) ShadeFmt
 
 // Return a function giving the color function corresponding to the level.
 // Beware, level start counting from 1.
-func shade(shades []shadeFmt) levelShadeFmt {
-	return func(level int) shadeFmt {
+func shade(shades []ShadeFmt) levelShadeFmt {
+	return func(level int) ShadeFmt {
 		if level < 1 {
 			level = 1
 		}


### PR DESCRIPTION
Export `ShadeFmt` to enable customization.

Issue: https://github.com/MichaelMure/go-term-markdown/issues/68